### PR TITLE
perf: serve the nearest thumbnail instead of the full original

### DIFF
--- a/app/api/photos/[id]/serve/route.ts
+++ b/app/api/photos/[id]/serve/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { S3Service } from '@/lib/s3';
+import {
+  resolveThumbnail,
+  IMMUTABLE_CACHE_CONTROL,
+  PROVISIONAL_CACHE_CONTROL,
+} from '@/lib/thumbnail-resolution';
 
 interface Params {
   id: string;
@@ -34,18 +39,30 @@ export async function GET(
       return NextResponse.json({ error: 'Photo not found' }, { status: 404 });
     }
 
-    let s3Key = photo.s3Key; // Default to original photo
-
-    // Try to find a thumbnail of the requested size
-    if (size !== 'original') {
-      const thumbnail = photo.thumbnails.find((t: any) => t.size.toLowerCase() === size.toLowerCase());
-      if (thumbnail) {
-        s3Key = thumbnail.s3Key;
-      }
-    }
-
-    // Get the image data directly from S3
     const s3Service = new S3Service();
+
+    let s3Key: string;
+    let cacheControl: string;
+
+    if (size === 'original') {
+      s3Key = photo.s3Key;
+      cacheControl = IMMUTABLE_CACHE_CONTROL;
+    } else {
+      const resolved = resolveThumbnail(photo.thumbnails, size);
+      if (!resolved) {
+        // No thumbnails exist yet (pre-generation, or the worker is behind). Redirect to
+        // a presigned URL rather than buffering a multi-MB original through Node, and
+        // keep the TTL short so clients pick up the real thumbnail once it lands.
+        const url = await s3Service.getSignedUrl(photo.s3Key, 3600);
+        return NextResponse.redirect(url, {
+          headers: { 'Cache-Control': PROVISIONAL_CACHE_CONTROL },
+        });
+      }
+      s3Key = resolved.s3Key;
+      // Only cache long-term when the bytes are the size that was actually requested;
+      // a substituted size must not be pinned for a year.
+      cacheControl = resolved.exact ? IMMUTABLE_CACHE_CONTROL : PROVISIONAL_CACHE_CONTROL;
+    }
     
     try {
       // Get the image data from S3
@@ -67,7 +84,7 @@ export async function GET(
       return new NextResponse(new Uint8Array(imageBuffer), {
         headers: {
           'Content-Type': contentType,
-          'Cache-Control': 'public, max-age=31536000, immutable',
+          'Cache-Control': cacheControl,
         },
       });
     } catch (s3Error) {

--- a/app/api/videos/[id]/serve/route.ts
+++ b/app/api/videos/[id]/serve/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { S3Service } from '@/lib/s3';
+import {
+  resolveThumbnail,
+  IMMUTABLE_CACHE_CONTROL,
+  PROVISIONAL_CACHE_CONTROL,
+} from '@/lib/thumbnail-resolution';
 
 interface Params {
   id: string;
@@ -34,20 +39,31 @@ export async function GET(
       return NextResponse.json({ error: 'Video not found' }, { status: 404 });
     }
 
-    let s3Key = video.s3Key; // Default to original video
-    let isVideoThumbnail = false;
-
-    // Try to find a thumbnail of the requested size
-    if (size !== 'original') {
-      const thumbnail = video.thumbnails.find((t: any) => t.size.toLowerCase() === size.toLowerCase());
-      if (thumbnail) {
-        s3Key = thumbnail.s3Key;
-        isVideoThumbnail = true;
-      }
-    }
-
-    // Get the video data directly from S3
     const s3Service = new S3Service();
+
+    let s3Key: string;
+    let isVideoThumbnail = false;
+    let cacheControl: string;
+
+    if (size === 'original') {
+      s3Key = video.s3Key;
+      cacheControl = IMMUTABLE_CACHE_CONTROL;
+    } else {
+      const resolved = resolveThumbnail(video.thumbnails, size);
+      if (!resolved) {
+        // No poster generated yet. Previously this buffered the entire video file into
+        // memory and served it as video/mp4 into an <Image> tag; redirect to a presigned
+        // URL instead so the bytes never pass through Node, with a short TTL so the real
+        // poster is picked up once the worker generates it.
+        const url = await s3Service.getSignedUrl(video.s3Key, 3600);
+        return NextResponse.redirect(url, {
+          headers: { 'Cache-Control': PROVISIONAL_CACHE_CONTROL },
+        });
+      }
+      s3Key = resolved.s3Key;
+      isVideoThumbnail = true;
+      cacheControl = resolved.exact ? IMMUTABLE_CACHE_CONTROL : PROVISIONAL_CACHE_CONTROL;
+    }
     
     try {
       // Get the video data from S3
@@ -87,7 +103,7 @@ export async function GET(
       return new NextResponse(new Uint8Array(videoBuffer), {
         headers: {
           'Content-Type': contentType,
-          'Cache-Control': 'public, max-age=31536000, immutable',
+          'Cache-Control': cacheControl,
           'Accept-Ranges': 'bytes', // Important for video seeking
         },
       });

--- a/lib/thumbnail-resolution.test.ts
+++ b/lib/thumbnail-resolution.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeSize,
+  resolveThumbnail,
+  type ResolvableThumbnail,
+} from './thumbnail-resolution';
+
+const t = (size: string, s3Key = `${size.toLowerCase()}.jpg`): ResolvableThumbnail => ({
+  size,
+  s3Key,
+});
+
+describe('normalizeSize', () => {
+  it('accepts known sizes case-insensitively', () => {
+    expect(normalizeSize('small')).toBe('SMALL');
+    expect(normalizeSize('MEDIUM')).toBe('MEDIUM');
+    expect(normalizeSize('Large')).toBe('LARGE');
+  });
+
+  it('rejects unknown sizes', () => {
+    expect(normalizeSize('original')).toBeNull();
+    expect(normalizeSize('xlarge')).toBeNull();
+    expect(normalizeSize('')).toBeNull();
+  });
+});
+
+describe('resolveThumbnail', () => {
+  it('prefers an exact match and reports it as exact', () => {
+    const got = resolveThumbnail([t('SMALL'), t('MEDIUM'), t('LARGE')], 'medium');
+    expect(got).toEqual({ s3Key: 'medium.jpg', exact: true });
+  });
+
+  it('falls up to the next larger size when the exact one is missing', () => {
+    const got = resolveThumbnail([t('MEDIUM'), t('LARGE')], 'small');
+    expect(got).toEqual({ s3Key: 'medium.jpg', exact: false });
+  });
+
+  it('skips gaps when falling up', () => {
+    const got = resolveThumbnail([t('LARGE')], 'small');
+    expect(got).toEqual({ s3Key: 'large.jpg', exact: false });
+  });
+
+  it('falls down to the largest smaller size when nothing larger exists', () => {
+    const got = resolveThumbnail([t('SMALL'), t('MEDIUM')], 'large');
+    expect(got).toEqual({ s3Key: 'medium.jpg', exact: false });
+  });
+
+  it('prefers falling up over falling down', () => {
+    const got = resolveThumbnail([t('SMALL'), t('LARGE')], 'medium');
+    expect(got).toEqual({ s3Key: 'large.jpg', exact: false });
+  });
+
+  it('returns null when there are no thumbnails — never the original', () => {
+    expect(resolveThumbnail([], 'small')).toBeNull();
+  });
+
+  it('returns null for an unrecognised requested size', () => {
+    expect(resolveThumbnail([t('SMALL')], 'original')).toBeNull();
+    expect(resolveThumbnail([t('SMALL')], 'huge')).toBeNull();
+  });
+
+  it('ignores rows with an unknown size or an empty key', () => {
+    expect(resolveThumbnail([{ size: 'TINY', s3Key: 'tiny.jpg' }], 'small')).toBeNull();
+    expect(resolveThumbnail([{ size: 'SMALL', s3Key: '' }], 'small')).toBeNull();
+  });
+
+  it('handles lowercase size values from the database', () => {
+    const got = resolveThumbnail([t('small')], 'small');
+    expect(got).toEqual({ s3Key: 'small.jpg', exact: true });
+  });
+});

--- a/lib/thumbnail-resolution.ts
+++ b/lib/thumbnail-resolution.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared nearest-size thumbnail resolution for the photo and video serve routes.
+ *
+ * Both routes used to match the requested size exactly and, on a miss, silently fall
+ * back to the full-resolution original — so a 300px grid tile could pull a multi-MB
+ * original whenever the thumbnail worker was behind. This picks the closest available
+ * thumbnail instead, and reports whether the match was exact so callers can decide how
+ * aggressively to cache the response.
+ *
+ * Ordering only. The pixel dimensions for each size live in THUMBNAIL_SIZES
+ * (lib/thumbnails.ts); that module pulls in sharp, so it is deliberately not imported
+ * here — this stays a dependency-free pure function.
+ */
+
+/** Smallest to largest. Matches the ThumbnailSize enum in prisma/schema.prisma. */
+const SIZE_ORDER = ['SMALL', 'MEDIUM', 'LARGE'] as const;
+
+export type ThumbnailSizeName = (typeof SIZE_ORDER)[number];
+
+export interface ResolvableThumbnail {
+  size: string;
+  s3Key: string;
+}
+
+export interface ResolvedThumbnail {
+  s3Key: string;
+  /** True when the returned thumbnail is exactly the size that was requested. */
+  exact: boolean;
+}
+
+/** Normalises a caller-supplied `?size=` value to a known size name, or null. */
+export function normalizeSize(requested: string): ThumbnailSizeName | null {
+  const upper = requested.toUpperCase();
+  return (SIZE_ORDER as readonly string[]).includes(upper)
+    ? (upper as ThumbnailSizeName)
+    : null;
+}
+
+/**
+ * Picks the best available thumbnail for a requested size.
+ *
+ * Preference order: exact match, then the next size up (better to downscale a slightly
+ * larger image than to upscale a smaller one), then the largest available size below.
+ *
+ * Returns null when there are no usable thumbnails at all, or when `requested` is not a
+ * recognised size — callers handle that case explicitly rather than getting the original
+ * by accident.
+ */
+export function resolveThumbnail(
+  thumbnails: ResolvableThumbnail[],
+  requested: string
+): ResolvedThumbnail | null {
+  const target = normalizeSize(requested);
+  if (!target) return null;
+
+  const available = new Map<string, string>();
+  for (const t of thumbnails) {
+    if (!t?.s3Key) continue;
+    const name = normalizeSize(t.size);
+    if (name) available.set(name, t.s3Key);
+  }
+  if (available.size === 0) return null;
+
+  const exactKey = available.get(target);
+  if (exactKey) return { s3Key: exactKey, exact: true };
+
+  const targetIndex = SIZE_ORDER.indexOf(target);
+
+  // Next size up, ascending.
+  for (let i = targetIndex + 1; i < SIZE_ORDER.length; i++) {
+    const key = available.get(SIZE_ORDER[i]);
+    if (key) return { s3Key: key, exact: false };
+  }
+
+  // Otherwise the largest available below the requested size.
+  for (let i = targetIndex - 1; i >= 0; i--) {
+    const key = available.get(SIZE_ORDER[i]);
+    if (key) return { s3Key: key, exact: false };
+  }
+
+  return null;
+}
+
+/** Long-lived caching is only safe when the bytes match what was asked for. */
+export const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+/**
+ * Short TTL for substituted or redirected responses, so clients pick up the real
+ * thumbnail once the worker generates it instead of holding a stand-in for a year.
+ */
+export const PROVISIONAL_CACHE_CONTROL = 'public, max-age=60';


### PR DESCRIPTION
PR A of the performance plan. Independent of the zip work; no migration.

## The bug

`app/api/photos/[id]/serve/route.ts` and `app/api/videos/[id]/serve/route.ts` matched the requested size exactly and, on a miss, fell through to the full-resolution original — the `if (thumbnail)` branch had no `else`, so `s3Key` kept its `photo.s3Key` default. A 300px grid tile could pull a multi-MB original (~250x the bytes needed), and the unconditional `max-age=31536000, immutable` then pinned that wrong body in browser and CDN caches for a **year**, even after the real thumbnail was generated.

Reachable in normal operation, not just in theory: the window between import and thumbnail generation, and any period where the BullMQ thumbnail worker is stopped or behind. `/api/admin/thumbnails/enqueue-missing` exists precisely because that state recurs.

## Changes

**`lib/thumbnail-resolution.ts`** (new) — one shared resolver: exact match → next larger → largest smaller, reporting whether the match was exact. Returns `null` only when there are no thumbnails at all, so callers can never get the original by accident.

Four call sites already hand-roll their own priority inline (`lib/data/album.ts:613-615`, `components/Album/MediaGrid.tsx:154`, `app/api/albums/route.ts:39`, and the two serve routes). This adds a resolver rather than a fifth variant. It deliberately does **not** import `THUMBNAIL_SIZES` from `lib/thumbnails.ts` — that module pulls in `sharp`, which would make a pure function untestable in isolation. Ordering lives in the resolver; pixel dimensions stay in `lib/thumbnails.ts`, and the comment says so.

**Conditional `Cache-Control`** — `immutable` only when the bytes are the size that was requested; a substituted size gets `max-age=60`. This is the part that actually fixes the cache poisoning. The fallback alone would still pin a stand-in for a year.

**No-thumbnails case** — 302 to a presigned URL instead of buffering the original through Node, reusing the pattern already in `app/api/photos/[id]/download/route.ts:31-34`. For videos this replaces buffering an entire video file into memory and serving it as `video/mp4` into an `<Image>` tag.

## Verification
- `tsc --noEmit` clean
- `vitest run` — 34 pass (23 existing + 11 new for the resolver)
- `npm run build` exit 0
- `eslint` on all four files — clean, no new problems

Behavioral checks worth doing on a real album before merge: delete a photo's SMALL row and confirm `?size=small` returns MEDIUM bytes with `max-age=60`; delete all its thumbnail rows and confirm a 302 with the image still rendering; confirm an untouched photo still gets `immutable`.

## Deliberately not included
`/api/videos/[id]/serve` still advertises `Accept-Ranges: bytes` without ever returning 206, and `MediaLightbox.tsx:389` normally points `<video>` at a LARGE JPEG. Both are real, both are correctness bugs in the video path rather than this fallback fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)